### PR TITLE
Fix issue #29

### DIFF
--- a/render.js
+++ b/render.js
@@ -40,7 +40,7 @@ function exec(commands, done) {
       done && done(e);
       return;
     }
-    page.open(svgfile, function(status) {
+    page.open('file:///'+svgfile, function(status) {
       if (status !== 'success') {
         var err = 'Error: Unable to load file (' + status + '): ' + svgfile;
         done && done(err);


### PR DESCRIPTION
The issue here is that PhantomJS 2 will not be able to parse any file from the file system to the browser.

For example:
The file path is: C:/abc/xxx.svg
This will be the URL in phantomJS: C:/abc/xxx.svg

Due to that, the error thrown by PhantomJS is that "C" is not a valid protocol (which indeed it isn't).
However, to read a file from the file system on a browser, the protocol is "file:///"
Thus, "file:///" has been prefixed to the file name as shown in the code.