### PR TITLE
convert path string to url

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,8 @@ function render(data, done) {
 
     // temporary fix for phantomjs+windows
     if (/^[a-z]\:\\/i.test(input[0])) {
-      input[0] = 'file:///' + input[0];
+      input[0] = input[0].replace(/\\/g, "/");
+      input[0] = 'file://' + input[0];
     }
 
     outputs.forEach(function(output) {

--- a/index.js
+++ b/index.js
@@ -105,7 +105,8 @@ function render(data, done) {
     // temporary fix for phantomjs+windows
     if (/^[a-z]\:\\/i.test(input[0])) {
       input[0] = input[0].replace(/\\/g, "/");
-      input[0] = 'file://' + input[0];
+      input[0] = 'file://' + input[0]; // three slash!!!
+      input[0] = encodeURI(input[0]); // for non-Engilish characters and white spaces
     }
 
     outputs.forEach(function(output) {


### PR DESCRIPTION
The `input[0]` will be open as an URL, not a path. For an URL, always use `/`. For an URL, it must be  encoded for special characters.