### PR TITLE
Set page load timeout from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Use a CSS to style input SVG:
 svgexport input.svg output.jpg "svg{background:silver;}"
 ```
 
-By default, Puppetteer has a page load timeout of 30 seconds. This might not be
+By default, Puppeteer has a page load timeout of 30 seconds. This might not be
 enough for large SVG files. If you want to change the page timeout, set the
 `TIMEOUT` environment variable to the desired number of seconds.
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ Use a CSS to style input SVG:
 svgexport input.svg output.jpg "svg{background:silver;}"
 ```
 
+By default, Puppetteer has a page load timeout of 30 seconds. This might not be
+enough for large SVG files. If you want to change the page timeout, set the
+`TIMEOUT` environment variable to the desired number of seconds.
+```bash
+// One minute timeout
+export TIMEOUT=60
+svgexport input.svg output.png
+```
+
 ### Node.js Module
 
 #### Installation

--- a/render.js
+++ b/render.js
@@ -23,6 +23,10 @@ async function renderSvg(commands, done, stdout) {
 
     var page = await browser.newPage();
 
+    if (process.env.TIMEOUT) {
+      await page.setDefaultNavigationTimeout(Number(process.env.TIMEOUT) * 1000);
+    }
+
     var svgfile = cmd.input[0];
     var imgfile = cmd.output[0];
     var params = [].concat(cmd.input.slice(1), cmd.output.slice(1));


### PR DESCRIPTION
Fixes #73 

If the `TIMEOUT` environment variable is set, use that to set the Puppeteer navigation timeout. Puppeteer expects the timeout in milliseconds, so the value of the environment variable is multiplied by 1000.

E.g.
```
> export TIMEOUT=1
> ./bin/index.js big.svg big.png
Error: Unable to load file (TimeoutError: Navigation timeout of 1000 ms exceeded): ...
```