### PR TITLE
Fix Windows paths by using URL constructor

### DIFF
--- a/render.js
+++ b/render.js
@@ -34,7 +34,7 @@ async function renderSvg(commands, done, stdout) {
     var imgfile = cmd.output[0];
     var params = [].concat(cmd.input.slice(1), cmd.output.slice(1));
 
-    await page.goto('file://' + encodeURI(svgfile))
+    await page.goto(encodeURI(String(new URL(`file://${svgfile}`))))
       .catch(function(e) { 
         throw 'Unable to load file (' + e + '): ' + svgfile;
       }


### PR DESCRIPTION
The URL constructor seems to correctly handle both Windows and Unix-style paths so should be the preferred way to generate File-URIs. This does require Node.js 10 or greated where the `URL` global was intruduced.

Some quick tests demonstrating the output:
````
> String(new URL(`file://c:\\a\\b.svg`))
'file:///c:/a/b.svg'
> String(new URL(`file:///a/b.svg`))
'file:///a/b.svg'
````