### PR TITLE
Support data URLs as input in addition to file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install svgexport -g
 
 #### Usage
 ```usage
-svgexport <input file> <output file> <options>
+svgexport <input file or data:url> <output file> <options>
 svgexport <datafile>
 
 <options>        [<format>] [<quality>] [<input viewbox>] [<output size>] [<resize mode>] [<styles>]
@@ -32,7 +32,7 @@ svgexport <datafile>
 
 <datafile>       Path of a JSON file with following content:
                  [ {
-                   "input" : ["<input file>", "<option>", "<option>", ...],
+                   "input" : ["<input file or data:url>", "<option>", "<option>", ...],
                    "output": [ ["<output file>", "<option>", "<option>", ...] ]
                  }, ...]
                  Input file options are merged with and overridden by output file options.

--- a/index.js
+++ b/index.js
@@ -87,8 +87,13 @@ async function render(data, done) {
 
     // TODO: Use /('[^']*'|"[^"]*"|[^"'\s])/ instead of split(/\s+/)
 
-    if (!Array.isArray(input)) {
-      input = input.split(/\s+/);
+    if (input != null) {
+      if (!Array.isArray(input)) {
+        input = input.split(/\s+/);
+      }
+      if (!input[0].startsWith("data:")) {
+        input[0] = path.resolve(cwd, input[0]);
+      }
     }
 
     if (!Array.isArray(outputs)) {
@@ -103,8 +108,6 @@ async function render(data, done) {
         return output.split(/\s+/);
       });
     }
-
-    input[0] = path.resolve(cwd, input[0]);
 
     outputs.forEach(function(output) {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svgexport",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/render.js
+++ b/render.js
@@ -31,13 +31,21 @@ async function renderSvg(commands, done, stdout) {
       await page.setDefaultNavigationTimeout(Number(process.env.SVGEXPORT_TIMEOUT) * 1000);
     }
 
-    var svgfile = cmd.input[0].split(path.sep)
-      .map((pathPart) => encodeURI(pathPart))
-      .join(path.sep);
+    var svgfile, svgurl;
+    if (cmd.input[0].startsWith('data:')) {
+      svgfile = 'SVG Data URL';
+      svgurl = cmd.input[0];
+    }
+    else {
+      svgfile = cmd.input[0].split(path.sep)
+          .map((pathPart) => encodeURI(pathPart))
+          .join(path.sep);
+      svgurl = 'file://' + svgfile;
+    }
     var imgfile = cmd.output[0];
     var params = [].concat(cmd.input.slice(1), cmd.output.slice(1));
 
-    await page.goto('file://' + svgfile)
+    await page.goto(svgurl)
       .catch(function(e) {
         throw 'Unable to load file (' + e + '): ' + svgfile;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,15 @@ describe('Module', function() {
       done();
     });
   });
+  it('trans.svg data url', function(done) {
+    svgexport.render({
+      'input' : "data:image/svg+xml;charset=UTF-8,%3c?xml version='1.0' encoding='UTF-8' standalone='no'?%3e%3csvg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' version='1.1' width='16' height='16'%3e%3crect width='12' height='2' x='2' y='0' style='fill:red;fill-opacity:1;stroke:none' /%3e%3crect width='12' height='2' x='2' y='14' style='fill:green;fill-opacity:1;stroke:none' /%3e%3crect width='2' height='12' x='0' y='2' style='fill:blue;fill-opacity:1;stroke:none' /%3e%3crect width='2' height='12' x='14' y='2' style='fill:yellow;fill-opacity:1;stroke:none' /%3e%3crect width='2' height='2' x='7' y='7' style='fill:gray;fill-opacity:1;stroke:none' /%3e%3crect width='1' height='1' x='7.5' y='7.5' style='fill:white;fill-opacity:1;stroke:none' /%3e%3c/svg%3e",
+      'output' : resolve('exported', 'trans-svg-from-data-url.png')
+    }, function(err) {
+      expect(err).not.be.ok;
+      done();
+    });
+  });
   it('test.json', function(done) {
     svgexport.render(resolve('test.json'), function(err) {
       expect(err).not.be.ok;


### PR DESCRIPTION
I have a collection of SVG path strings for which I need to generate icons.
Added support for `data:` urls (e.g. `data:image+svg/xml;...`) to avoid having to generate temporary svg files.