### PR TITLE
Fix font spacing in docker environments

### DIFF
--- a/render.js
+++ b/render.js
@@ -19,7 +19,7 @@ async function renderSvg(commands, done, stdout) {
 
   var browser = await puppeteer.launch({
     headless: true,
-    args: ['--no-sandbox']
+    args: ['--no-sandbox', '--font-render-hinting=none']
   });
 
   // Run each command in parallel.


### PR DESCRIPTION
Dear @shakiba,
Thank you for this amazing project. It makes exporting svgs to pngs so much easier. I found an issue with font spacing in docker environments and created this PR to fix it. I would very much appreciate if you could have a look at this.

This PR adds the `--font-render-hinting=none` argument when launching puppeteer. This fixes font spacing issues when running chrome in headless mode in docker environments. See [this thread](https://github.com/puppeteer/puppeteer/issues/2410) in the puppeteer issue tracker for more details.

Before this change: Spacing between single characters are off (see 9 or 0 in the example below)

![mw-legend](https://user-images.githubusercontent.com/1810384/100256368-ffc03400-2f44-11eb-8aa3-604aef4c2f78.png)

After this change: Spacing between single characters looks organic

![mw-after](https://user-images.githubusercontent.com/1810384/100256462-18c8e500-2f45-11eb-88a7-325b72e18170.png)

